### PR TITLE
Fix the typo of pluse to pulse

### DIFF
--- a/PyNaoServer/NaoProxyManager.cpp
+++ b/PyNaoServer/NaoProxyManager.cpp
@@ -47,7 +47,7 @@ NaoProxyManager * NaoProxyManager::s_pNaoProxyManager = NULL;
 
 void * pulse_thread( void * controller )
 {
-  ((NaoProxyManager *)controller)->continuePluseChestLED();
+  ((NaoProxyManager *)controller)->continuePulseChestLED();
   return NULL;
 }
 
@@ -824,7 +824,7 @@ void NaoProxyManager::fini()
 }
 
 // helper function
-void NaoProxyManager::continuePluseChestLED()
+void NaoProxyManager::continuePulseChestLED()
 {
   fd_set dummyFDSet;
   struct timeval timeout;

--- a/PyNaoServer/NaoProxyManager.h
+++ b/PyNaoServer/NaoProxyManager.h
@@ -87,7 +87,7 @@ public:
   
   void setChestLED( const NAOLedColour colour );
   void pulsatingChestLED( const NAOLedColour colour1, const NAOLedColour colour2, const float period = 0.5 );
-  void continuePluseChestLED();
+  void continuePulseChestLED();
   
   void getBatteryStatus( int & percentage, bool & isplugged, bool & ischarging, bool & isdischarging );
 

--- a/PyNaoServer/PyNAOModule.cpp
+++ b/PyNaoServer/PyNAOModule.cpp
@@ -1251,7 +1251,7 @@ static PyObject * PyModule_NaoSSetChestLED( PyObject * self, PyObject * args )
   Py_RETURN_NONE;
 }
 
-/*! \fn pluseChestLED(colour_one, colour_two, period)
+/*! \fn pulseChestLED(colour_one, colour_two, period)
  *  \memberof PyNAO
  *  \brief Periodically switch NAO's chest LED between the two input colours.
  *  \param str colour_one. Colour label one.
@@ -1260,7 +1260,7 @@ static PyObject * PyModule_NaoSSetChestLED( PyObject * self, PyObject * args )
  *  \return None.
  *  \note Colour must be 'red','green', 'blue', 'white', 'blank', 'yellow' or 'pink'.
  */
-static PyObject * PyModule_NaoPluseChestLED( PyObject * self, PyObject * args )
+static PyObject * PyModule_NaoPulseChestLED( PyObject * self, PyObject * args )
 {
   char * colourStr1 = NULL;
   char * colourStr2 = NULL;
@@ -1274,18 +1274,25 @@ static PyObject * PyModule_NaoPluseChestLED( PyObject * self, PyObject * args )
     return NULL;
   }
   if (!colourStr2ID( colourStr1, colourID1 ) || !colourStr2ID( colourStr2, colourID2 )) {
-    PyErr_Format( PyExc_ValueError, "PyNAO.pluseChestLED: invalid input colour(s)."
+    PyErr_Format( PyExc_ValueError, "PyNAO.pulseChestLED: invalid input colour(s)."
                  "Colour must be 'red','green', 'blue', 'white', 'blank', 'yellow' or 'pink'." );
     return NULL;
   }
 
   if (period <= 0.0) {
-    PyErr_Format( PyExc_ValueError, "PyNAO.pluseChestLED: invalid pluse period." );
+    PyErr_Format( PyExc_ValueError, "PyNAO.pulseChestLED: invalid pulse period." );
     return NULL;
   }
 
   NaoProxyManager::instance()->pulsatingChestLED( colourID1, colourID2, period );
   Py_RETURN_NONE;
+}
+
+// Deprecation warning call
+static PyObject * PyModule_NaoPluseChestLED( PyObject * self, PyObject * args )
+{
+  PyErr_Format( PyExc_ValueError, "PyNAO.pulseChestLED: Deprecation warning! Substitute your pluseChestLED calls for pulseChestLED." );
+  return PyModule_NaoPulseChestLED(self, args);
 }
 
 /*! \fn getBatteryStatus()
@@ -1395,7 +1402,9 @@ static PyMethodDef PyModule_methods[] = {
   { "setChestLED", (PyCFunction)PyModule_NaoSSetChestLED, METH_VARARGS,
     "Set the colour of the chest LEDs on NAO." },
   { "pluseChestLED", (PyCFunction)PyModule_NaoPluseChestLED, METH_VARARGS,
-    "Pluse the chest LED of NAO between two colours." },
+    "Deprecated, use pulseChestLED." },
+  { "pulseChestLED", (PyCFunction)PyModule_NaoPulseChestLED, METH_VARARGS,
+    "Pulse the chest LED of NAO between two colours." },
   { "getBatteryStatus", (PyCFunction)PyModule_NaoGetBatteryStatus, METH_NOARGS,
     "Get the current battery status." },
 #define DEFINE_COMMON_PYMODULE_METHODS

--- a/scripts/tinstate.py
+++ b/scripts/tinstate.py
@@ -13,7 +13,7 @@ def updateStatus( state, negate ):
 
   #set chest LED
   if status & constants.NEW_MESSAGES:
-    PyNAO.pluseChestLED( 'red', 'white', 0.5 )
+    PyNAO.pulseChestLED( 'red', 'white', 0.5 )
   elif status & constants.ARCHIVE_MESSAGES:
     if status & constants.USER_PRESENT:
       PyNAO.setChestLED( 'pink' )


### PR DESCRIPTION
I can't compile it to try if I missed something.

I guess you have already working software somewhere so I added a deprecation warning on the original "pluse" call.
